### PR TITLE
JS bundling with Rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ Thumbs.db
 *.sql
 *.sqlite
 
+# IDE Config #
+##############
+/.vscode
+
 # Custom #
 ######################
 *.sublime-project

--- a/dev/.babelrc
+++ b/dev/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    ["latest", {
+      "es2015": {
+        "modules": false
+      }
+    }]
+  ],
+  "plugins": ["external-helpers"]
+}

--- a/dev/index.html
+++ b/dev/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Title Here</title>
-  <link rel="stylesheet" href="styles/style.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 
 <body>
@@ -28,6 +28,6 @@
 </div>
 </section>
 
-<script src="public/scripts/main.js"></script>
+<script src="bundle.js"></script>
 </body>
 </html>

--- a/dev/scripts/main.js
+++ b/dev/scripts/main.js
@@ -1,3 +1,3 @@
-const ohHey = "Hello World";
+import { say, message } from './utils'
 
-console.log(ohHey);
+say(message)

--- a/dev/scripts/utils.js
+++ b/dev/scripts/utils.js
@@ -1,0 +1,5 @@
+export function say (msg) {
+  console.info(`%c ${msg} `, 'background: purple; color: white; padding: 4px 2px')
+}
+
+export const message = 'Hello World 👋 🎉'

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-latest": "^6.24.1",
     "browser-sync": "^2.18.8",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
-    "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.1",
-    "gulp-sass": "^3.1.0"
+    "gulp-sass": "^3.1.0",
+    "rollup": "^0.41.6",
+    "rollup-plugin-babel": "^2.7.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,9 @@
+const babel = require('rollup-plugin-babel');
+const transpiler = babel({ exclude: 'node_modules/**' })
+
+module.exports = {
+  format: 'iife',
+  entry: './dev/scripts/main.js',
+  dest: './public/bundle.js',
+  plugins: [ transpiler ]
+}


### PR DESCRIPTION
Hi 👋 

Rollup is still pretty new compared to Browserify / Webpack / jspm / SystemJS, etc... but I feel like its  minimalist approach and focus on ES6 fits your project nicely.

In a nutshell, Rollup lets you write bleeding-edge ES6 style modules and have them bundled up into widely supported formats (roughly analogous to the way babel transpiles ES6 code into ES5).

### Things of note

* babel transpiling is now done via a plugin into rollup (they need to play nicely together)
* moved `style.css` and `bundle.js` out of `public/styles/` and `public/scripts/` respectively, since there should only ever be one file in each directory
* put the rollup configuration in its own config file so that you can also build using their cli (`npm i -g rollup` then `rollup -c` from the repo) - the gulpfile reuses that config
* rollup allows for bundling into a number of formats (AMD, Common.JS, IIFE) - I opted for IIFE which is best suited for including your bundle via script tag alone

:man_technologist: :tipping_hand_man: 